### PR TITLE
Change behavior of `colcheck` command

### DIFF
--- a/config/bashrc.d/ros2_common.bash
+++ b/config/bashrc.d/ros2_common.bash
@@ -14,7 +14,7 @@ ccolbuil() {
 
 colcheck() {
   local pkg=$1
-  colcon build --packages-select $pkg
+  colcon build --packages-up-to $pkg
   colcon test --packages-select $pkg
   colcon test-result --verbose
 }


### PR DESCRIPTION
Colcheck command only build the package specified and it does **not** build dependent local packages.
Here I changed `--packages-select `-> `--packages-up-to` for `colcon build` options, and now `colcheck hoge` also build dependent packages.