### PR TITLE
add ros-dev-tools

### DIFF
--- a/install/ros2/install.sh
+++ b/install/ros2/install.sh
@@ -12,7 +12,8 @@ _install_ubuntu() {
 
   sudo apt-get update && sudo apt-get install -y \
     ros-${ROS_DISTRO}-desktop \
-    python3-rosdep
+    python3-rosdep \
+    ros-dev-tools
 
   sudo apt-get update && sudo apt-get install -y \
     build-essential \


### PR DESCRIPTION
Please add `ros-dev-tools` to install all ROS-related build tools at once.

[Reference (Humble)](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html#install-ros-2-packages)