### PR TITLE
tmux attach sessions

### DIFF
--- a/config/bashrc.d/ros1_melodic.bash
+++ b/config/bashrc.d/ros1_melodic.bash
@@ -34,11 +34,32 @@ melodic_exec_setup() {
 melodic_open() {
   local ROS_DISTRO="melodic"
   local session_name="${ROS_DISTRO}_ide"
-  tmux new-session -s $session_name \; \
-    split-window -v \; \
-    select-pane -t 0 \; \
-    send-keys -t 0 "${ROS_DISTRO}_devel_setup" C-m \; \
-    send-keys -t 1 "${ROS_DISTRO}_exec_setup" C-m \;
+
+  local ws_name
+  case $# in
+  0)
+    ws_name=$ROS_DISTRO
+    ;;
+  1)
+    ws_name=$1
+    ;;
+  *)
+    echo "Invalid number of argument given." >&2
+    return
+    ;;
+  esac
+
+  tmux has-session -t $session_name 2>/dev/null
+
+  if [ $? != 0 ]; then
+    tmux new-session -s $session_name \; \
+      split-window -v \; \
+      select-pane -t 0 \; \
+      send-keys -t 0 "${ROS_DISTRO}_devel_setup $ws_name" C-m \; \
+      send-keys -t 1 "${ROS_DISTRO}_exec_setup $ws_name" C-m \;
+  else
+    tmux attach -t $session_name
+  fi
 }
 
 # Close tmux panes

--- a/config/bashrc.d/ros1_noetic.bash
+++ b/config/bashrc.d/ros1_noetic.bash
@@ -34,11 +34,32 @@ noetic_exec_setup() {
 noetic_open() {
   local ROS_DISTRO="noetic"
   local session_name="${ROS_DISTRO}_ide"
-  tmux new-session -s $session_name \; \
-    split-window -v \; \
-    select-pane -t 0 \; \
-    send-keys -t 0 "${ROS_DISTRO}_devel_setup" C-m \; \
-    send-keys -t 1 "${ROS_DISTRO}_exec_setup" C-m \;
+
+  local ws_name
+  case $# in
+  0)
+    ws_name=$ROS_DISTRO
+    ;;
+  1)
+    ws_name=$1
+    ;;
+  *)
+    echo "Invalid number of argument given." >&2
+    return
+    ;;
+  esac
+
+  tmux has-session -t $session_name 2>/dev/null
+
+  if [ $? != 0 ]; then
+    tmux new-session -s $session_name \; \
+      split-window -v \; \
+      select-pane -t 0 \; \
+      send-keys -t 0 "${ROS_DISTRO}_devel_setup $ws_name" C-m \; \
+      send-keys -t 1 "${ROS_DISTRO}_exec_setup $ws_name" C-m \;
+  else
+    tmux attach -t $session_name
+  fi
 }
 
 # Close tmux panes

--- a/config/bashrc.d/ros2_foxy.bash
+++ b/config/bashrc.d/ros2_foxy.bash
@@ -44,11 +44,32 @@ foxy_exec_setup() {
 foxy_open() {
   local ROS_DISTRO="foxy"
   local session_name="${ROS_DISTRO}_ide"
-  tmux new-session -s $session_name \; \
-    split-window -v \; \
-    select-pane -t 0 \; \
-    send-keys -t 0 "${ROS_DISTRO}_devel_setup" C-m \; \
-    send-keys -t 1 "${ROS_DISTRO}_exec_setup" C-m \;
+
+  local ws_name
+  case $# in
+  0)
+    ws_name=$ROS_DISTRO
+    ;;
+  1)
+    ws_name=$1
+    ;;
+  *)
+    echo "Invalid number of argument given." >&2
+    return
+    ;;
+  esac
+
+  tmux has-session -t $session_name 2>/dev/null
+
+  if [ $? != 0 ]; then
+    tmux new-session -s $session_name \; \
+      split-window -v \; \
+      select-pane -t 0 \; \
+      send-keys -t 0 "${ROS_DISTRO}_devel_setup $ws_name" C-m \; \
+      send-keys -t 1 "${ROS_DISTRO}_exec_setup $ws_name" C-m \;
+  else
+    tmux attach -t $session_name
+  fi
 }
 
 # Close tmux panes

--- a/config/bashrc.d/ros2_galactic.bash
+++ b/config/bashrc.d/ros2_galactic.bash
@@ -87,11 +87,17 @@ galactic_open() {
     ;;
   esac
 
-  tmux new-session -s $session_name \; \
-    split-window -v \; \
-    select-pane -t 0 \; \
-    send-keys -t 0 "${ROS_DISTRO}_devel_setup $ws_name" C-m \; \
-    send-keys -t 1 "${ROS_DISTRO}_exec_setup $ws_name" C-m \;
+  tmux has-session -t $session_name 2>/dev/null
+
+  if [ $? != 0 ]; then
+    tmux new-session -s $session_name \; \
+      split-window -v \; \
+      select-pane -t 0 \; \
+      send-keys -t 0 "${ROS_DISTRO}_devel_setup $ws_name" C-m \; \
+      send-keys -t 1 "${ROS_DISTRO}_exec_setup $ws_name" C-m \;
+  else
+    tmux attach -t $session_name
+  fi
 }
 
 # Close tmux panes

--- a/config/bashrc.d/ros2_humble.bash
+++ b/config/bashrc.d/ros2_humble.bash
@@ -87,11 +87,17 @@ humble_open() {
     ;;
   esac
 
-  tmux new-session -s $session_name \; \
-    split-window -v \; \
-    select-pane -t 0 \; \
-    send-keys -t 0 "${ROS_DISTRO}_devel_setup $ws_name" C-m \; \
-    send-keys -t 1 "${ROS_DISTRO}_exec_setup $ws_name" C-m \;
+  tmux has-session -t $session_name 2>/dev/null
+
+  if [ $? != 0 ]; then
+    tmux new-session -s $session_name \; \
+      split-window -v \; \
+      select-pane -t 0 \; \
+      send-keys -t 0 "${ROS_DISTRO}_devel_setup $ws_name" C-m \; \
+      send-keys -t 1 "${ROS_DISTRO}_exec_setup $ws_name" C-m \;
+  else
+    tmux attach -t $session_name
+  fi
 }
 
 # Close tmux panes


### PR DESCRIPTION
# Before this PR
`humble_open` fails to create new sessions when `humble_ide` session alive.

# After 
`humble_open` tries to attach exiting sessions if it alive.


## NOTE
Also this features available for
- `noetic`
- `melodic`
- `foxy`
- `galactic`
